### PR TITLE
Modify memory use

### DIFF
--- a/framework/packet.c
+++ b/framework/packet.c
@@ -26,24 +26,22 @@ struct sockaddr_in  {
  * 4. Check packet data fields for value overflows and allowed ranges
 */
 
-int _packet_verify_flags_flow(PacketFlags *packetFlags);
-int _packet_verify_flags_type(PacketFlags *packetFlags);
-int _packet_verify_flags_target(PacketFlags *packetFlags);
-int _packet_verify_flags_action(PacketFlags *packetFlags);
-int _packet_verify_flags_respond(PacketFlags *packetFlags);
-int _packet_verify_flags_window(PacketFlags *packetFlags);
-int _packet_verify_flags_config(PacketFlags *packetFlags);
-int _packet_verify_flags_init(PacketFlags *packetFlags);
+int _packet_verify_flags_flow(PacketFlags packetFlags);
+int _packet_verify_flags_type(PacketFlags packetFlags);
+int _packet_verify_flags_target(PacketFlags packetFlags);
+int _packet_verify_flags_action(PacketFlags packetFlags);
+int _packet_verify_flags_respond(PacketFlags packetFlags);
+int _packet_verify_flags_window(PacketFlags packetFlags);
+int _packet_verify_flags_config(PacketFlags packetFlags);
+int _packet_verify_flags_init(PacketFlags packetFlags);
 
 char *pack_json(Packet *packet) {
     char *packed = NULL;
     return packed;
 }
 
-Packet *unpack_json(char *packed) {
-    Packet *packet = malloc(sizeof(Packet));
-    packet->flags = malloc(sizeof(PacketFlags));
-    return packet;
+int unpack_json(char *packed, Packet *destPacket) {
+    return 0;
 }
 
 char *pack_binary(Packet *packet) {
@@ -51,13 +49,11 @@ char *pack_binary(Packet *packet) {
     return packed;
 }
 
-Packet *unpack_binary(char *packed) {
-    Packet *packet = malloc(sizeof(Packet));
-    packet->flags = malloc(sizeof(PacketFlags));
-    return packet;
+int unpack_binary(char *packed, Packet *destPacket) {
+    return 0;
 }
 
-int packet_verify(Packet *packet) {
+int packet_verify(const Packet *packet) {
     int result = 1;
     result *= packet_verify_id(packet);
     result *= packet_verify_flags(packet);
@@ -72,7 +68,7 @@ int packet_verify(Packet *packet) {
     return result;
 }
 
-int packet_verify_id(Packet *packet) {
+int packet_verify_id(const Packet *packet) {
     if (! (0 < packet->id && packet->id < 65536)) {
         // value out of range, error
         return 0;
@@ -80,7 +76,7 @@ int packet_verify_id(Packet *packet) {
     return 1;
 }
 
-int packet_verify_flags(Packet *packet) {
+int packet_verify_flags(const Packet *packet) {
     int result = 1;
     result *= _packet_verify_flags_flow(packet->flags);
     result *= _packet_verify_flags_type(packet->flags);
@@ -93,81 +89,81 @@ int packet_verify_flags(Packet *packet) {
     return result;
 }
 
-int packet_verify_request_address(Packet *packet) {
+int packet_verify_request_address(const Packet *packet) {
     struct sockaddr_in *placeholder = NULL;
     int result = inet_pton(AF_INET, packet->request_address, (void *) &placeholder);
     return 0 != result;
 }
 
-int packet_verify_response_address(Packet *packet) {
+int packet_verify_response_address(const Packet *packet) {
     struct sockaddr_in *placeholder = NULL;
     int test = inet_pton(AF_INET, packet->response_address, (void *) &placeholder);
     return 0 != test;
 }
 
-int packet_verify_data_window_start(Packet *packet, int now) {
+int packet_verify_data_window_start(const Packet *packet, int now) {
     return packet->data_window_start < now ? 1 : 0;
 }
 
-int packet_verify_data_window_stop(Packet *packet, int now) {
+int packet_verify_data_window_stop(const Packet *packet, int now) {
     return packet->data_window_stop < now ? 1 : 0;
 }
 
-int packet_verify_data_window_causal(Packet *packet) {
+int packet_verify_data_window_causal(const Packet *packet) {
     return packet->data_window_start <= packet->data_window_stop ? 1 : 0;
 }
 
-int _packet_verify_flags_flow(PacketFlags *packetFlags) {
-    if (! (0 == packetFlags->flow || 1 == packetFlags->flow)) {
+int _packet_verify_flags_flow(PacketFlags packetFlags) {
+    if (! (0 == packetFlags.flow || 1 == packetFlags.flow)) {
         return 0;
     }
     return 1;
 }
 
-int _packet_verify_flags_type(PacketFlags *packetFlags) {
-    if (! (0 == packetFlags->type || 1 == packetFlags->type)) {
+int _packet_verify_flags_type(PacketFlags packetFlags) {
+    if (! (0 == packetFlags.type || 1 == packetFlags.type)) {
         return 0;
     }
     return 1;
 }
 
-int _packet_verify_flags_target(PacketFlags *packetFlags) {
-    if (! (0 == packetFlags->target || 1 == packetFlags->target)) {
+int _packet_verify_flags_target(PacketFlags packetFlags) {
+    if (! (0 == packetFlags.target || 1 == packetFlags.target)) {
         return 0;
     }
     return 1;
 }
 
-int _packet_verify_flags_action(PacketFlags *packetFlags) {
-    if (! (0 == packetFlags->action || 1 == packetFlags->action)) {
+int _packet_verify_flags_action(PacketFlags packetFlags) {
+    if (! (0 == packetFlags.action || 1 == packetFlags.action)) {
         return 0;
     }
     return 1;
 }
 
-int _packet_verify_flags_respond(PacketFlags *packetFlags) {
-    if (! (0 == packetFlags->respond || 1 == packetFlags->respond)) {
+int _packet_verify_flags_respond(PacketFlags packetFlags) {
+    if (! (0 == packetFlags.respond || 1 == packetFlags.respond)) {
         return 0;
     }
     return 1;
 }
 
-int _packet_verify_flags_window(PacketFlags *packetFlags) {
-    if (! (0 == packetFlags->window || 1 == packetFlags->window)) {
+int _packet_verify_flags_window(PacketFlags packetFlags) {
+    if (! (0 == packetFlags.window || 1 == packetFlags.window)) {
         return 0;
     }
     return 1;
 }
 
-int _packet_verify_flags_config(PacketFlags *packetFlags) {
-    if (! (0 == packetFlags->config || 1 == packetFlags->config)) {
+int _packet_verify_flags_config(PacketFlags packetFlags) {
+    if (! (0 == packetFlags.config || 1 == packetFlags.config)) {
         return 0;
     }
     return 1;
 }
 
-int _packet_verify_flags_init(PacketFlags *packetFlags) {
-    if (! (0 == packetFlags->init || 1 == packetFlags->init)) {
+int _packet_verify_flags_init(PacketFlags packetFlags) {
+    if (! (0 == packetFlags.init || 1 == packetFlags.init)) {
         return 0;
     }
     return 1;

--- a/framework/packet.h
+++ b/framework/packet.h
@@ -35,7 +35,7 @@ struct Packet {
     // 2 byte int
     int id;
     // flags struct
-    PacketFlags *flags;
+    PacketFlags flags;
     // 6 bytes : ip/port
     char *request_address;
     // 6 bytes : ip/port
@@ -50,12 +50,15 @@ struct Packet {
 };
 
 char *pack(Packet *packet);
-Packet *unpack(char *packed);
-int packet_verify(Packet *packet);
-int packet_verify_id(Packet *packet);
-int packet_verify_flags(Packet *packet);
-int packet_verify_request_address(Packet *packet);
-int packet_verify_response_address(Packet *packet);
-int packet_verify_data_window_start(Packet *packet, int now);
-int packet_verify_data_window_stop(Packet *packet, int now);
-int packet_verify_data_window_causal(Packet *packet);
+// Unpack JSON string into destPacket
+int unpack_json(char *packed, Packet *destPacket);
+int unpack_binary(char *packed, Packet *destPacket);
+
+int packet_verify(const Packet *packet);
+int packet_verify_id(const Packet *packet);
+int packet_verify_flags(const Packet *packet);
+int packet_verify_request_address(const Packet *packet);
+int packet_verify_response_address(const Packet *packet);
+int packet_verify_data_window_start(const Packet *packet, int now);
+int packet_verify_data_window_stop(const Packet *packet, int now);
+int packet_verify_data_window_causal(const Packet *packet);

--- a/framework/tcpclient.c
+++ b/framework/tcpclient.c
@@ -86,7 +86,7 @@ void tcp_send_message(void * receive_buffer, struct sockaddr_in serverAddress) {
     tcp_write_message(receive_buffer, socket_resource);
     tcp_read_response(receive_buffer, socket_resource);
 
-    printf("Server response a: %s\n", receive_buffer);
+    printf("Server response a: %s\n", (char *)receive_buffer);
     close(socket_resource);
 }
 

--- a/framework/udpclient.c
+++ b/framework/udpclient.c
@@ -77,7 +77,7 @@ void udp_send_message(void * receive_buffer, struct sockaddr_in serverAddress) {
     udp_write_message(receive_buffer, socket_resource, serverAddress);
     udp_read_response(receive_buffer, socket_resource, serverAddress);
 
-    printf("Server response a: %s\n", receive_buffer);
+    printf("Server response a: %s\n", (char *)receive_buffer);
     close(socket_resource);
 }
 

--- a/test.c
+++ b/test.c
@@ -12,45 +12,43 @@
 #include <unistd.h>
 
 void testPacket() {
-    Packet *packet = malloc(sizeof(Packet));
-    packet->flags = malloc(sizeof(PacketFlags));
+    Packet packet;
+    packet.flags.action = 1;
+    packet.flags.config = 1;
+    packet.flags.flow = 0;
+    packet.flags.init = 0;
+    packet.flags.respond = 0;
+    packet.flags.target = 0;
+    packet.flags.type = 0;
+    packet.flags.window = 0;
 
-    packet->flags->action = 1;
-    packet->flags->config = 1;
-    packet->flags->flow = 0;
-    packet->flags->init = 0;
-    packet->flags->respond = 0;
-    packet->flags->target = 0;
-    packet->flags->type = 0;
-    packet->flags->window = 0;
+    packet.id = 1;
+    packet.data_window_start = 1000;
+    packet.data_window_stop = 1001;
+    packet.request_address = "127.0.0.1";
+    packet.response_address = "127.0.0.1";
+    packet.payload = "Bravo Marko, care! :D";
 
-    packet->id = 1;
-    packet->data_window_start = 1000;
-    packet->data_window_stop = 1001;
-    packet->request_address = "127.0.0.1";
-    packet->response_address = "127.0.0.1";
-    packet->payload = "Bravo Marko, care! :D";
-
-    int response = packet_verify(packet);
+    int response = packet_verify(&packet);
     sleep(1);
 
     if (response > 0) {
-        printf("Packet tested successfully (%lu, %lu)\n", sizeof(packet), sizeof(packet->flags));
+        printf("Packet tested successfully (%lu)\n", sizeof(Packet));
     } else {
         printf("Supplied packet isn't valid DNA format\n");
     }
 }
 
 void testConfigs() {
-    Request *request = malloc(sizeof(Request));
-    Response *response = malloc(sizeof(Response));
-    ConfigurationConsumer *config_consumer = malloc(sizeof(ConfigurationConsumer));
-    ConfigurationProducer *config_producer = malloc(sizeof(ConfigurationProducer));
-    ConfigurationServiceAgent *config_serviceAgent = malloc(sizeof(ConfigurationServiceAgent));
-    ConfigurationQualityOfService *config_qualityOfService = malloc(sizeof(ConfigurationQualityOfService));
+    Request request;
+    Response response;
+    ConfigurationConsumer config_consumer;
+    ConfigurationProducer config_producer;
+    ConfigurationServiceAgent config_serviceAgent;
+    ConfigurationQualityOfService config_qualityOfService;
 
-    request_init(request);
-    response_init(response);
+    request_init(&request);
+    response_init(&response);
 
     char *consumerHost = "127.0.0.1";
     char *producerHost = "127.0.0.1";
@@ -60,25 +58,25 @@ void testConfigs() {
     int qosPort = 9877;
 //    char *producerEndpoint = "/histogram";
 
-    config_producer->host = producerHost;
-    config_producer->port = producerPort;
-    config_consumer->host = consumerHost;
-    config_consumer->port = consumerPort;
+    config_producer.host = producerHost;
+    config_producer.port = producerPort;
+    config_consumer.host = consumerHost;
+    config_consumer.port = consumerPort;
 
-    config_serviceAgent->consumerHost = consumerHost;
-    config_serviceAgent->consumerPort = consumerPort;
-    config_serviceAgent->producerHost = producerHost;
-    config_serviceAgent->producerPort = producerPort;
+    config_serviceAgent.consumerHost = consumerHost;
+    config_serviceAgent.consumerPort = consumerPort;
+    config_serviceAgent.producerHost = producerHost;
+    config_serviceAgent.producerPort = producerPort;
 
-    config_qualityOfService->host = qosHost;
-    config_qualityOfService->port = qosPort;
+    config_qualityOfService.host = qosHost;
+    config_qualityOfService.port = qosPort;
 
-    printf("Quality of service host: %s\n", config_qualityOfService->host);
-    printf("Consumer host: %s\n", config_consumer->host);
-    printf("Producer host: %s\n", config_producer->host);
-    printf("Quality of service port: %d\n", config_qualityOfService->port);
-    printf("Consumer port: %d\n", config_consumer->port);
-    printf("Producer port: %d\n", config_producer->port);
+    printf("Quality of service host: %s\n", config_qualityOfService.host);
+    printf("Consumer host: %s\n", config_consumer.host);
+    printf("Producer host: %s\n", config_producer.host);
+    printf("Quality of service port: %d\n", config_qualityOfService.port);
+    printf("Consumer port: %d\n", config_consumer.port);
+    printf("Producer port: %d\n", config_producer.port);
 }
 
 void testClients() {
@@ -86,7 +84,7 @@ void testClients() {
     int target_message_count = 500;
     int target_thread_count = 1;
     int thread_count = 6;
-    Task *task[thread_count];
+    Task task[thread_count];
     char *testHost[] = {"127.0.0.1", "127.0.0.1", "127.0.0.1", "127.0.0.1", "127.0.0.1", "127.0.0.1"};
     // first three are TCP clients
     // second three are UDP clients
@@ -95,12 +93,11 @@ void testClients() {
 
     // creating and initializing tasks
     for (int i = 0; i < 6; i++) {
-        task[i] = malloc(sizeof(Task));
-        task[i]->host = testHost[i];
-        task[i]->port = testPort[i];
-        task[i]->message = message;
-        task[i]->repeat_count = target_message_count;
-        task[i]->thread_count = target_thread_count;
+        task[i].host = testHost[i];
+        task[i].port = testPort[i];
+        task[i].message = message;
+        task[i].repeat_count = target_message_count;
+        task[i].thread_count = target_thread_count;
     }
 
     // dispatching threads for individual tcp/udp clients
@@ -123,22 +120,18 @@ void testClients() {
         }
 
     }
-
-    for (int i = 0; i < 6; i++) {
-        free(task[i]);
-    }
 }
 
 void testDevice() {
     char* path = "storage/example.conf";
     char* mode = "r";
-    Device *device = malloc(sizeof(*device));
+    Device device;
     int result;
 
-    result = ServiceAgentDeviceConfiguration(path, mode, device);
+    result = ServiceAgentDeviceConfiguration(path, mode, &device);
 
     if (result) {
-        printf("Host: %s, port: %d\n\n", device->host, device->port);
+        printf("Host: %s, port: %d\n\n", device.host, device.port);
     } else {
         printf("Error reading device configuration\n");
     }

--- a/test.c
+++ b/test.c
@@ -12,45 +12,43 @@
 #include <unistd.h>
 
 void testPacket() {
-    Packet *packet = malloc(sizeof(Packet));
-    packet->flags = malloc(sizeof(PacketFlags));
+    Packet packet;
+    packet.flags.action = 1;
+    packet.flags.config = 1;
+    packet.flags.flow = 0;
+    packet.flags.init = 0;
+    packet.flags.respond = 0;
+    packet.flags.target = 0;
+    packet.flags.type = 0;
+    packet.flags.window = 0;
 
-    packet->flags->action = 1;
-    packet->flags->config = 1;
-    packet->flags->flow = 0;
-    packet->flags->init = 0;
-    packet->flags->respond = 0;
-    packet->flags->target = 0;
-    packet->flags->type = 0;
-    packet->flags->window = 0;
+    packet.id = 1;
+    packet.data_window_start = 1000;
+    packet.data_window_stop = 1001;
+    packet.request_address = "127.0.0.1";
+    packet.response_address = "127.0.0.1";
+    packet.payload = "Bravo Marko, care! :D";
 
-    packet->id = 1;
-    packet->data_window_start = 1000;
-    packet->data_window_stop = 1001;
-    packet->request_address = "127.0.0.1";
-    packet->response_address = "127.0.0.1";
-    packet->payload = "Bravo Marko, care! :D";
-
-    int response = packet_verify(packet);
+    int response = packet_verify(&packet);
     sleep(1);
 
     if (response > 0) {
-        printf("Packet tested successfully (%lu, %lu)\n", sizeof(packet), sizeof(packet->flags));
+        printf("Packet tested successfully (%lu)\n", sizeof(Packet));
     } else {
         printf("Supplied packet isn't valid DNA format\n");
     }
 }
 
 void testConfigs() {
-    Request *request = malloc(sizeof(Request));
-    Response *response = malloc(sizeof(Response));
-    ConfigurationConsumer *config_consumer = malloc(sizeof(ConfigurationConsumer));
-    ConfigurationProducer *config_producer = malloc(sizeof(ConfigurationProducer));
-    ConfigurationServiceAgent *config_serviceAgent = malloc(sizeof(ConfigurationServiceAgent));
-    ConfigurationQualityOfService *config_qualityOfService = malloc(sizeof(ConfigurationQualityOfService));
+    Request request;
+    Response response;
+    ConfigurationConsumer config_consumer;
+    ConfigurationProducer config_producer;
+    ConfigurationServiceAgent config_serviceAgent;
+    ConfigurationQualityOfService config_qualityOfService;
 
-    request_init(request);
-    response_init(response);
+    request_init(&request);
+    response_init(&response);
 
     char *consumerHost = "127.0.0.1";
     char *producerHost = "127.0.0.1";
@@ -60,25 +58,25 @@ void testConfigs() {
     int qosPort = 9877;
 //    char *producerEndpoint = "/histogram";
 
-    config_producer->host = producerHost;
-    config_producer->port = producerPort;
-    config_consumer->host = consumerHost;
-    config_consumer->port = consumerPort;
+    config_producer.host = producerHost;
+    config_producer.port = producerPort;
+    config_consumer.host = consumerHost;
+    config_consumer.port = consumerPort;
 
-    config_serviceAgent->consumerHost = consumerHost;
-    config_serviceAgent->consumerPort = consumerPort;
-    config_serviceAgent->producerHost = producerHost;
-    config_serviceAgent->producerPort = producerPort;
+    config_serviceAgent.consumerHost = consumerHost;
+    config_serviceAgent.consumerPort = consumerPort;
+    config_serviceAgent.producerHost = producerHost;
+    config_serviceAgent.producerPort = producerPort;
 
-    config_qualityOfService->host = qosHost;
-    config_qualityOfService->port = qosPort;
+    config_qualityOfService.host = qosHost;
+    config_qualityOfService.port = qosPort;
 
-    printf("Quality of service host: %s\n", config_qualityOfService->host);
-    printf("Consumer host: %s\n", config_consumer->host);
-    printf("Producer host: %s\n", config_producer->host);
-    printf("Quality of service port: %d\n", config_qualityOfService->port);
-    printf("Consumer port: %d\n", config_consumer->port);
-    printf("Producer port: %d\n", config_producer->port);
+    printf("Quality of service host: %s\n", config_qualityOfService.host);
+    printf("Consumer host: %s\n", config_consumer.host);
+    printf("Producer host: %s\n", config_producer.host);
+    printf("Quality of service port: %d\n", config_qualityOfService.port);
+    printf("Consumer port: %d\n", config_consumer.port);
+    printf("Producer port: %d\n", config_producer.port);
 }
 
 void testClients() {
@@ -86,7 +84,7 @@ void testClients() {
     int target_message_count = 500;
     int target_thread_count = 1;
     int thread_count = 6;
-    Task *task[thread_count];
+    Task task[thread_count];
     char *testHost[] = {"127.0.0.1", "127.0.0.1", "127.0.0.1", "127.0.0.1", "127.0.0.1", "127.0.0.1"};
     // first three are TCP clients
     // second three are UDP clients
@@ -95,12 +93,11 @@ void testClients() {
 
     // creating and initializing tasks
     for (int i = 0; i < 6; i++) {
-        task[i] = malloc(sizeof(Task));
-        task[i]->host = testHost[i];
-        task[i]->port = testPort[i];
-        task[i]->message = message;
-        task[i]->repeat_count = target_message_count;
-        task[i]->thread_count = target_thread_count;
+        task[i].host = testHost[i];
+        task[i].port = testPort[i];
+        task[i].message = message;
+        task[i].repeat_count = target_message_count;
+        task[i].thread_count = target_thread_count;
     }
 
     // dispatching threads for individual tcp/udp clients
@@ -112,9 +109,9 @@ void testClients() {
         for (int i = 0; i < thread_count; i++) {
             pthread_attr_init(&(attributes[i]));
             if (i < 3) {
-                pthread_create(&(thread[i]), &(attributes[i]), (void *) tcp_client, task[i]);
+                pthread_create(&(thread[i]), &(attributes[i]), (void *) tcp_client, &task[i]);
             } else {
-                pthread_create(&(thread[i]), &(attributes[i]), (void *) udp_client, task[i]);
+                pthread_create(&(thread[i]), &(attributes[i]), (void *) udp_client, &task[i]);
             }
         }
 
@@ -123,22 +120,18 @@ void testClients() {
         }
 
     }
-
-    for (int i = 0; i < 6; i++) {
-        free(task[i]);
-    }
 }
 
 void testDevice() {
     char* path = "storage/example.conf";
     char* mode = "r";
-    Device *device = malloc(sizeof(*device));
+    Device device;
     int result;
 
-    result = ServiceAgentDeviceConfiguration(path, mode, device);
+    result = ServiceAgentDeviceConfiguration(path, mode, &device);
 
     if (result) {
-        printf("Host: %s, port: %d\n\n", device->host, device->port);
+        printf("Host: %s, port: %d\n\n", device.host, device.port);
     } else {
         printf("Error reading device configuration\n");
     }


### PR DESCRIPTION
Packet can contain PacketFlags directly, it would save on complexity for memory management.
Most of the allocations can also be saved on, and kept on stack.

See if this still matches your model.